### PR TITLE
Chore: Unify logger

### DIFF
--- a/infrastructure/router.go
+++ b/infrastructure/router.go
@@ -3,7 +3,6 @@ package infrastructure
 import (
 	"clean-architecture/lib"
 	"clean-architecture/utils"
-	"fmt"
 	"net/http"
 
 	"github.com/getsentry/sentry-go"
@@ -18,18 +17,23 @@ type Router struct {
 }
 
 //NewRouter : all the routes are defined here
-func NewRouter(env lib.Env) Router {
+func NewRouter(
+	env lib.Env,
+	logger lib.Logger,
+) Router {
 
 	if env.Environment != "local" && env.SentryDSN != "" {
 		if err := sentry.Init(sentry.ClientOptions{
 			Dsn:         env.SentryDSN,
 			Environment: `clean-backend-` + env.Environment,
 		}); err != nil {
-			fmt.Printf("Sentry initialization failed: %v\n", err)
+			logger.Infof("Sentry initialization failed: %v\n", err)
 		}
 	}
 
+	gin.DefaultWriter = logger.GetGinLogger()
 	httpRouter := gin.Default()
+
 	httpRouter.MaxMultipartMemory = env.MaxMultipartMemory
 
 	httpRouter.Use(cors.New(cors.Config{

--- a/lib/env.go
+++ b/lib/env.go
@@ -1,8 +1,6 @@
 package lib
 
 import (
-	"log"
-
 	"github.com/spf13/viper"
 )
 
@@ -30,19 +28,18 @@ func GetEnv() Env {
 	return globalEnv
 }
 
-func NewEnv() Env {
+func NewEnv(logger Logger) Env {
 	viper.SetConfigFile(".env")
 
 	err := viper.ReadInConfig()
 	if err != nil {
-		log.Fatal("cannot read cofiguration")
+		logger.Fatal("cannot read cofiguration")
 	}
 
 	err = viper.Unmarshal(&globalEnv)
 	if err != nil {
-		log.Fatal("environment cant be loaded: ", err)
+		logger.Fatal("environment cant be loaded: ", err)
 	}
 
-	log.Printf("%#v \n", &globalEnv)
 	return globalEnv
 }

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -4,5 +4,5 @@ import "go.uber.org/fx"
 
 var Module = fx.Options(
 	fx.Provide(NewEnv),
-	fx.Provide(NewLogger),
+	fx.Provide(GetLogger),
 )

--- a/lib/logger.go
+++ b/lib/logger.go
@@ -1,28 +1,44 @@
 package lib
 
 import (
+	"context"
+	"os"
+	"time"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	gormlogger "gorm.io/gorm/logger"
 )
 
-var globalLog Logger
+var globalLog *Logger
 
 // Logger structure
 type Logger struct {
 	*zap.SugaredLogger
 }
 
+type GormLogger struct {
+	*Logger
+	gormlogger.Config
+}
+
 // GetLogger gets the global instance of the logger
 func GetLogger() Logger {
-	return globalLog
+	if globalLog != nil {
+		return *globalLog
+	}
+	globalLog := newLogger()
+	return *globalLog
 }
 
 // NewLogger sets up logger
-func NewLogger(env Env) Logger {
+func newLogger() *Logger {
 
+	env := os.Getenv("ENVIRONMENT")
 	config := zap.NewDevelopmentConfig()
 
-	if env.Environment == "local" {
+	if env == "local" {
 		config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 	} else {
 		config.Level.SetLevel(zap.PanicLevel)
@@ -32,8 +48,79 @@ func NewLogger(env Env) Logger {
 
 	globalLog := logger.Sugar()
 
-	return Logger{
-		globalLog,
+	return &Logger{
+		SugaredLogger: globalLog,
 	}
 
+}
+
+// GetGormLogger build gorm logger from zap logger
+func (l *Logger) GetGormLogger() gormlogger.Interface {
+	return &GormLogger{
+		Logger: l,
+		Config: gormlogger.Config{
+			LogLevel: gormlogger.Info,
+		},
+	}
+}
+
+// ------ GORM logger interface implementation -----
+
+// LogMode set log mode
+func (l *GormLogger) LogMode(level gormlogger.LogLevel) gormlogger.Interface {
+	newlogger := *l
+	newlogger.LogLevel = level
+	return &newlogger
+}
+
+// Info prints info
+func (l GormLogger) Info(ctx context.Context, str string, args ...interface{}) {
+	if l.LogLevel >= gormlogger.Info {
+		l.Debugf(str, args...)
+	}
+}
+
+// Warn prints warn messages
+func (l GormLogger) Warn(ctx context.Context, str string, args ...interface{}) {
+	if l.LogLevel >= gormlogger.Warn {
+		l.Warnf(str, args...)
+	}
+
+}
+
+// Error prints error messages
+func (l GormLogger) Error(ctx context.Context, str string, args ...interface{}) {
+	if l.LogLevel >= gormlogger.Error {
+		l.Errorf(str, args...)
+	}
+}
+
+// Trace prints trace messages
+func (l GormLogger) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
+	if l.LogLevel <= 0 {
+		return
+	}
+	elapsed := time.Since(begin)
+	if l.LogLevel >= gormlogger.Info {
+		sql, rows := fc()
+		l.Debug("[", elapsed.Milliseconds(), " ms, ", rows, " rows] ", "sql -> ", sql)
+		return
+	}
+
+	if l.LogLevel >= gormlogger.Warn {
+		sql, rows := fc()
+		l.SugaredLogger.Warn("[", elapsed.Milliseconds(), " ms, ", rows, " rows] ", "sql -> ", sql)
+		return
+	}
+
+	if l.LogLevel >= gormlogger.Error {
+		sql, rows := fc()
+		l.SugaredLogger.Error("[", elapsed.Milliseconds(), " ms, ", rows, " rows] ", "sql -> ", sql)
+		return
+	}
+}
+
+// Printf prints go-fx logs
+func (l Logger) Printf(str string, args ...interface{}) {
+	l.Infof(str, args)
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"clean-architecture/bootstrap"
+	"clean-architecture/lib"
 
 	"github.com/joho/godotenv"
 	"go.uber.org/fx"
@@ -10,5 +11,6 @@ import (
 func main() {
 	godotenv.Load()
 
-	fx.New(bootstrap.Module).Run()
+	logger := lib.GetLogger()
+	fx.New(bootstrap.Module, fx.Logger(logger)).Run()
 }

--- a/main.go
+++ b/main.go
@@ -12,5 +12,5 @@ func main() {
 	godotenv.Load()
 
 	logger := lib.GetLogger()
-	fx.New(bootstrap.Module, fx.Logger(logger)).Run()
+	fx.New(bootstrap.Module, fx.Logger(logger.GetFxLogger())).Run()
 }


### PR DESCRIPTION
We currently use different loggers for different purposes.
- main app: zap
- gorm: gorm logger
- fx and viper uses their own logger

This pull request adds sub-loggers for `gorm`, `viper`, `go-fx` by implementing the package's required logging interfaces.

Now everything will use zap logger instead of different loggers. 

#### Screenshot:
![image](https://user-images.githubusercontent.com/8201857/128028591-adf429cf-eafe-49bf-8ac9-1aea98aa157c.png)
