### PR TITLE
Multiple files upload under same key

### DIFF
--- a/api/controllers/user_controller.go
+++ b/api/controllers/user_controller.go
@@ -6,6 +6,7 @@ import (
 	"clean-architecture/models"
 	"clean-architecture/services"
 	"clean-architecture/utils"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -63,6 +64,12 @@ func (u UserController) SaveUser(c *gin.Context) {
 			"error": err.Error(),
 		})
 		return
+	}
+
+	metadata, _ := c.MustGet(constants.File).(lib.UploadedFiles)
+	files := metadata.GetMultipleFiles("files[]")
+	for i := range files {
+		fmt.Println(files[i])
 	}
 
 	if err := u.service.Create(user); err != nil {

--- a/api/middlewares/upload_middleware.go
+++ b/api/middlewares/upload_middleware.go
@@ -87,6 +87,7 @@ func (u UploadMiddleware) Config() UploadConfig {
 		Extensions:       []Extension{JPEGFile, PNGFile, JPGFile},
 		ThumbnailEnabled: false,
 		ThumbnailWidth:   100,
+		Multiple:         false,
 	}
 }
 

--- a/api/middlewares/upload_middleware.go
+++ b/api/middlewares/upload_middleware.go
@@ -6,6 +6,7 @@ import (
 	"clean-architecture/constants"
 	"clean-architecture/lib"
 	"clean-architecture/services"
+	"context"
 	"errors"
 	"fmt"
 	"image"
@@ -13,6 +14,7 @@ import (
 	"image/png"
 	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -56,6 +58,9 @@ type UploadConfig struct {
 
 	// WebpEnabled set whether thumbnail is enabled or nor
 	WebpEnabled bool
+
+	// Multiple set whether to upload multiple files with same key name
+	Multiple bool
 }
 
 type UploadMiddleware struct {
@@ -115,11 +120,19 @@ func (cfg UploadConfig) WebpEnable(enable bool) UploadConfig {
 	return cfg
 }
 
+// MultipleFilesUpload enable multiple files to be uploaded with same key name
+func (cfg UploadConfig) MultipleFilesUpload(enable bool) UploadConfig {
+	cfg.Multiple = enable
+	return cfg
+}
+
 // Push adds file upload configuration
 func (u UploadMiddleware) Push(config UploadConfig) UploadMiddleware {
 	u.config = append(u.config, config)
 	return u
 }
+
+var uploadedFiles []lib.UploadMetadata
 
 // Handle handles file upload
 func (u UploadMiddleware) Handle() gin.HandlerFunc {
@@ -131,117 +144,39 @@ func (u UploadMiddleware) Handle() gin.HandlerFunc {
 
 		errGroup, ctx := errgroup.WithContext(c.Request.Context())
 
-		uploadedFiles := []lib.UploadMetadata{}
-
 		for i := range u.config {
 			conf := u.config[i]
+			if conf.Multiple {
+				form, _ := c.MultipartForm()
+				files := form.File[conf.FieldName]
+				for j := range files {
+					file, err := files[j].Open()
+					if err != nil {
+						responses.ErrorJSON(c, http.StatusInternalServerError, err)
+						c.Abort()
+						return
+					}
+					defer file.Close()
 
-			file, fileHeader, _ := c.Request.FormFile(conf.FieldName)
-
-			if file != nil && fileHeader != nil {
-
-				ext := filepath.Ext(fileHeader.Filename)
-				if !u.matchesExtension(conf, ext) {
-					u.logger.Error("file-upload-error: ", ErrExtensionMismatch.Error())
+					err = u.uploadFile(errGroup, ctx, conf, file, files[j])
+					if err != nil {
+						u.logger.Error("file-upload-error: ", err.Error())
+						responses.ErrorJSON(c, http.StatusInternalServerError, err.Error())
+						c.Abort()
+						return
+					}
+				}
+			} else {
+				file, fileHeader, _ := c.Request.FormFile(conf.FieldName)
+				err := u.uploadFile(errGroup, ctx, conf, file, fileHeader)
+				if err != nil {
+					u.logger.Error("file-upload-error: ", err.Error())
 					responses.ErrorJSON(c, http.StatusInternalServerError, ErrExtensionMismatch.Error())
 					c.Abort()
 					return
 				}
-
-				fileByte, err := ioutil.ReadAll(file)
-				if err != nil {
-					u.logger.Error("file-upload-error: ", ErrFileRead)
-					responses.ErrorJSON(c, http.StatusInternalServerError, ErrFileRead)
-					c.Abort()
-					return
-				}
-
-				uploadFileName, fileUID := u.randomFileName(conf, ext)
-				fileReader := bytes.NewReader(fileByte)
-				errGroup.Go(func() error {
-					urlResponse, err := u.bucket.UploadFile(ctx, fileReader, uploadFileName, fileHeader.Filename)
-					uploadedFiles = append(uploadedFiles, lib.UploadMetadata{
-						FieldName: conf.FieldName,
-						FileName:  fileHeader.Filename,
-						URL:       urlResponse,
-						FileUID:   fileUID,
-						Size:      fileHeader.Size,
-					})
-					return err
-				})
-
-				// original image
-				if conf.WebpEnabled && u.properExtension(ext) {
-					origWebpReader := bytes.NewReader(fileByte)
-					errGroup.Go(func() error {
-						var webpBuf bytes.Buffer
-						img, err := u.getImage(origWebpReader, ext)
-						if err != nil {
-							return err
-						}
-
-						if err := webp.Encode(&webpBuf, img, &webp.Options{Lossless: true}); err != nil {
-							return err
-						}
-
-						webpReader := bytes.NewReader(webpBuf.Bytes())
-						resizeFileName := u.bucketPath(conf, fmt.Sprintf("%s_webp%s", fileUID, ext))
-
-						if _, err := u.bucket.UploadFile(ctx, webpReader, resizeFileName, strings.ReplaceAll(fileHeader.Filename, ext, "")+".webp"); err != nil {
-							return err
-						}
-
-						return nil
-					})
-				}
-
-				if conf.ThumbnailEnabled {
-					thumbReader := bytes.NewReader(fileByte)
-					errGroup.Go(func() error {
-						if !u.properExtension(ext) {
-							return ErrExtensionMismatch
-						}
-						// Genrate non-webp thumbnail
-						img, err := u.createThumbnail(conf, thumbReader, ext)
-						if err != nil {
-							return err
-						}
-
-						resizeFileName := u.bucketPath(conf, fmt.Sprintf("%s_thumb%s", fileUID, ext))
-						_, err = u.bucket.UploadFile(ctx, img, resizeFileName, fileHeader.Filename)
-						if err != nil {
-							return err
-						}
-						return nil
-					})
-
-					if conf.WebpEnabled && u.properExtension(ext) {
-						webpReader := bytes.NewReader(fileByte)
-						errGroup.Go(func() error {
-							var webpBuf bytes.Buffer
-							img, err := u.getImage(webpReader, ext)
-							if err != nil {
-								return err
-							}
-
-							resizeImage := resize.Resize(conf.ThumbnailWidth, 0, img, resize.Lanczos3)
-							if err := webp.Encode(&webpBuf, resizeImage, &webp.Options{Lossless: true}); err != nil {
-								return err
-							}
-
-							webpReader := bytes.NewReader(webpBuf.Bytes())
-							resizeFileName := u.bucketPath(conf, fmt.Sprintf("%s_thumb%s", fileUID, ".webp"))
-
-							_, err = u.bucket.UploadFile(ctx, webpReader, resizeFileName, fileHeader.Filename)
-							if err != nil {
-								return err
-							}
-
-							return nil
-						})
-					}
-				}
 			}
+
 		}
 		if err := errGroup.Wait(); err != nil {
 			u.logger.Error("file-upload-error: ", err.Error())
@@ -258,6 +193,107 @@ func (u UploadMiddleware) Handle() gin.HandlerFunc {
 		c.Next()
 
 	}
+}
+
+func (u UploadMiddleware) uploadFile(errGroup *errgroup.Group, ctx context.Context, conf UploadConfig, file multipart.File, fileHeader *multipart.FileHeader) error {
+	if file != nil && fileHeader != nil {
+		ext := filepath.Ext(fileHeader.Filename)
+		if !u.matchesExtension(conf, ext) {
+			return ErrExtensionMismatch
+		}
+
+		fileByte, err := ioutil.ReadAll(file)
+		if err != nil {
+			return ErrFileRead
+		}
+
+		uploadFileName, fileUID := u.randomFileName(conf, ext)
+		fileReader := bytes.NewReader(fileByte)
+		errGroup.Go(func() error {
+			urlResponse, err := u.bucket.UploadFile(ctx, fileReader, uploadFileName, fileHeader.Filename)
+			uploadedFiles = append(uploadedFiles, lib.UploadMetadata{
+				FieldName: conf.FieldName,
+				FileName:  fileHeader.Filename,
+				URL:       urlResponse,
+				FileUID:   fileUID,
+				Size:      fileHeader.Size,
+			})
+			return err
+		})
+
+		// original image
+		if conf.WebpEnabled && u.properExtension(ext) {
+			origWebpReader := bytes.NewReader(fileByte)
+			errGroup.Go(func() error {
+				var webpBuf bytes.Buffer
+				img, err := u.getImage(origWebpReader, ext)
+				if err != nil {
+					return err
+				}
+
+				if err := webp.Encode(&webpBuf, img, &webp.Options{Lossless: true}); err != nil {
+					return err
+				}
+
+				webpReader := bytes.NewReader(webpBuf.Bytes())
+				resizeFileName := u.bucketPath(conf, fmt.Sprintf("%s_webp%s", fileUID, ext))
+
+				if _, err := u.bucket.UploadFile(ctx, webpReader, resizeFileName, strings.ReplaceAll(fileHeader.Filename, ext, "")+".webp"); err != nil {
+					return err
+				}
+
+				return nil
+			})
+		}
+
+		if conf.ThumbnailEnabled {
+			thumbReader := bytes.NewReader(fileByte)
+			errGroup.Go(func() error {
+				if !u.properExtension(ext) {
+					return ErrExtensionMismatch
+				}
+				// Genrate non-webp thumbnail
+				img, err := u.createThumbnail(conf, thumbReader, ext)
+				if err != nil {
+					return err
+				}
+
+				resizeFileName := u.bucketPath(conf, fmt.Sprintf("%s_thumb%s", fileUID, ext))
+				_, err = u.bucket.UploadFile(ctx, img, resizeFileName, fileHeader.Filename)
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+
+			if conf.WebpEnabled && u.properExtension(ext) {
+				webpReader := bytes.NewReader(fileByte)
+				errGroup.Go(func() error {
+					var webpBuf bytes.Buffer
+					img, err := u.getImage(webpReader, ext)
+					if err != nil {
+						return err
+					}
+
+					resizeImage := resize.Resize(conf.ThumbnailWidth, 0, img, resize.Lanczos3)
+					if err := webp.Encode(&webpBuf, resizeImage, &webp.Options{Lossless: true}); err != nil {
+						return err
+					}
+
+					webpReader := bytes.NewReader(webpBuf.Bytes())
+					resizeFileName := u.bucketPath(conf, fmt.Sprintf("%s_thumb%s", fileUID, ".webp"))
+
+					_, err = u.bucket.UploadFile(ctx, webpReader, resizeFileName, fileHeader.Filename)
+					if err != nil {
+						return err
+					}
+
+					return nil
+				})
+			}
+		}
+	}
+	return nil
 }
 
 func (u UploadMiddleware) properExtension(ext string) bool {

--- a/api/routes/user_routes.go
+++ b/api/routes/user_routes.go
@@ -39,7 +39,9 @@ func (s UserRoutes) Setup() {
 	{
 		api.GET("/user", s.userController.GetUser)
 		api.GET("/user/:id", s.userController.GetOneUser)
-		api.POST("/user", s.userController.SaveUser)
+		api.POST("/user",
+			s.uploadMiddleware.Push(s.uploadMiddleware.Config().Field("files[]").ThumbEnable(true).WebpEnable(true).MultipleFilesUpload(true)).Handle(),
+			s.userController.SaveUser)
 		api.PUT("/user/:id",
 			s.uploadMiddleware.Push(s.uploadMiddleware.Config().ThumbEnable(true).WebpEnable(true)).Handle(),
 			s.userController.UpdateUser,

--- a/lib/file_metadata.go
+++ b/lib/file_metadata.go
@@ -19,3 +19,13 @@ func (f UploadedFiles) GetFile(fieldName string) UploadMetadata {
 	}
 	return UploadMetadata{}
 }
+
+func (f UploadedFiles) GetMultipleFiles(fieldName string) []UploadMetadata {
+	var files []UploadMetadata
+	for _, file := range f {
+		if file.FieldName == fieldName {
+			files = append(files, file)
+		}
+	}
+	return files
+}


### PR DESCRIPTION
**What has been done:**
* Add 'Multiple' field in 'UploadConfig' to check whether to upload multiple files or not for the given 'key'
* Update 'upload middleware' to support multiple files upload under same 'key'/'name'
* Add func to get all uploaded files under same 'key'/'name'
* Add example to upload multiple files under key 'files[]' in 'Create User' API

**Note:**
* [] should be used at the end of field name as it helps to create array of files 
* For example: files[] => POSTMANkey is files[]; Use files[] in multiple rows and select the files to upload multiple files under same key name

**Jira Issue:**
https://wesionary-team.atlassian.net/secure/RapidBoard.jspa?rapidView=50&projectKey=SYS&modal=detail&selectedIssue=SYS-73