### PR TITLE
Chore: Update `Dockerfile` according to golang version

### DIFF
--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -1,20 +1,13 @@
 FROM golang:alpine
 
 # Required because go requires gcc to build
-RUN apk add build-base
-
-RUN apk add inotify-tools
-
+RUN apk add build-base git inotify-tools
 RUN echo $GOPATH
+RUN go install github.com/rubenv/sql-migrate/...@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 COPY . /clean_web
-
-RUN go get github.com/rubenv/sql-migrate/...
-
 WORKDIR /clean_web
-
 RUN go mod download
-
-RUN go get github.com/go-delve/delve/cmd/dlv
 
 CMD sh /clean_web/docker/run.sh


### PR DESCRIPTION
The current `Dockerfile` breaks build as it installs the new golang version. 
This is a part of code from #61 by @paudelgaurav. 

Since we are not merging #61 anytime soon because of GCP support for the new version. 
Let's merge this. 🙏 