### PR TITLE
Remove dependency from https://github.com/dnephin/pre-commit-golang

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: git://github.com/dnephin/pre-commit-golang
-    rev: master
+-   repo: https://github.com/golangci/golangci-lint.git
+    rev: v1.52.1
     hooks:
     -   id: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-include .env
 export
 
 MIGRATE=docker-compose exec web sql-migrate
@@ -28,11 +27,9 @@ create:
 	${MIGRATE} new $$NAME
 
 lint-setup:
-	curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
-	sudo python2 get-pip.py
-	sudo pip install pre-commit
-	rm get-pip.py
+	python3 -m ensurepip --upgrade
+	sudo pip3 install pre-commit
 	pre-commit install
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.43.0
+	pre-commit autoupdate
 
 .PHONY: migrate-status migrate-up migrate-down redo create lint-setup

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+include .env
 export
 
 MIGRATE=docker-compose exec web sql-migrate

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Clean Architecture with [Gin Web Framework](https://github.com/gin-gonic/gin)
 
 ## Linter setup
 
-To add linter in git pre-commit hook, and install all the required packages for setting up linter.
+Python3 is required to add linter in git pre-commit hook.
 
 ```zsh
 make lint-setup

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Clean Architecture with [Gin Web Framework](https://github.com/gin-gonic/gin)
 
 ## Linter setup
 
-Need [Python3](https://www.python.org/) setup linter in git pre-commit hook.
+Need [Python3](https://www.python.org/) to setup linter in git pre-commit hook.
 
 ```zsh
 make lint-setup

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Clean Architecture with [Gin Web Framework](https://github.com/gin-gonic/gin)
 
 ## Linter setup
 
-Python3 is required to add linter in git pre-commit hook.
+Need [Python3](https://www.python.org/) setup linter in git pre-commit hook.
 
 ```zsh
 make lint-setup


### PR DESCRIPTION
golangci-lint is directly supported by [pre-commit](https://pre-commit.com/) so removing the dependency from https://github.com/dnephin/pre-commit-golang

Python3 is required to install [pre-commit](https://pre-commit.com/)
I have tested on macOS 13.2.1 and arch