### PR TITLE
BAC-36 | add seed:run cli command

### DIFF
--- a/console/commands/run_seed.go
+++ b/console/commands/run_seed.go
@@ -1,0 +1,77 @@
+package commands
+
+import (
+	"clean-architecture/pkg/framework"
+	"clean-architecture/seeds"
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+type SeedCommand struct {
+	names  []string
+	runAll bool
+}
+
+func (s *SeedCommand) Short() string {
+	return "run seed command"
+}
+
+func NewSeedCommand() *SeedCommand {
+	return &SeedCommand{}
+}
+
+func (s *SeedCommand) Setup(cmd *cobra.Command) {
+	cmd.Flags().StringArrayVarP(
+		&s.names,
+		"name",
+		"n",
+		[]string{},
+		"name of the seed to run (can be used multiple times)",
+	)
+	cmd.Flags().BoolVar(&s.runAll, "all", false, "run all seeds")
+}
+
+func (s *SeedCommand) Run() framework.CommandRunner {
+	return func(
+		l framework.Logger,
+		seeds seeds.Seeds,
+	) {
+
+		// run all seeds
+		if s.runAll {
+			for _, seed := range seeds {
+				seed.Setup()
+			}
+			return
+		}
+
+		// validate names array
+		if len(s.names) == 0 {
+			l.Info("no seed name provided")
+			return
+		}
+
+		// run selected seeds
+		for _, name := range s.names {
+			if err := runSeed(name, &seeds); err != nil {
+				l.Infof("Error running %s: %s", name, err)
+			}
+		} // end for loop
+	} // end return func
+} // end run func
+
+func runSeed(name string, seeds *seeds.Seeds) error {
+	isValid := false
+	for _, seed := range *seeds {
+		if name == seed.Name() {
+			isValid = true
+			seed.Setup()
+		}
+	} // end for loop
+
+	if !isValid {
+		return errors.New("invalid seed name")
+	}
+	return nil
+} // end runSeed func

--- a/console/console.go
+++ b/console/console.go
@@ -12,6 +12,7 @@ import (
 var cmds = map[string]framework.Command{
 	"cmd:random": commands.NewRandomCommand(),
 	"app:serve":  NewServeCommand(),
+	"seed:run":   commands.NewSeedCommand(),
 }
 
 // GetSubCommands gives a list of sub commands

--- a/console/serve.go
+++ b/console/serve.go
@@ -4,7 +4,6 @@ import (
 	"clean-architecture/pkg/framework"
 	"clean-architecture/pkg/infrastructure"
 	"clean-architecture/pkg/middlewares"
-	"clean-architecture/seeds"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -27,7 +26,6 @@ func (s *ServeCommand) Run() framework.CommandRunner {
 		router infrastructure.Router,
 		logger framework.Logger,
 		database infrastructure.Database,
-		seeds seeds.Seeds,
 
 	) {
 		logger.Info(`+-----------------------+`)
@@ -39,7 +37,6 @@ func (s *ServeCommand) Run() framework.CommandRunner {
 		time.Local = loc
 
 		middleware.Setup()
-		seeds.Setup()
 
 		if env.Environment != "local" && env.SentryDSN != "" {
 			err := sentry.Init(sentry.ClientOptions{

--- a/seeds/admin_seed.go
+++ b/seeds/admin_seed.go
@@ -28,6 +28,10 @@ func NewAdminSeed(
 	}
 }
 
+func (as AdminSeed) Name() string {
+	return "AdminSeed"
+}
+
 // Run admin seeder
 func (as AdminSeed) Setup() {
 	// Create email manually in firebase

--- a/seeds/seeds.go
+++ b/seeds/seeds.go
@@ -10,18 +10,13 @@ var Module = fx.Options(
 
 // Seed db seed
 type Seed interface {
+	// name is used to identify the seed
+	Name() string
 	Setup()
 }
 
 // Seeds listing of seeds
 type Seeds []Seed
-
-// Run run the seed data
-func (s Seeds) Setup() {
-	for _, seed := range s {
-		seed.Setup()
-	}
-}
 
 // NewSeeds creates new seeds
 func NewSeeds(adminSeed AdminSeed) Seeds {


### PR DESCRIPTION
### **What the PR contains:**

- [x] add seed:run cli command 
- [x] Disable seeds from running on every start

This PR adds new `seed:run` cli command:
Example Usage: `go run  main.go seed:run -n TestSeed -n AdminSeed` 

Command Help:
```
/clean_web # go run  main.go seed:run -h
run seed command

Usage:
  clean-architecture seed:run [flags]

Flags:
      --all                run all seeds
  -h, --help               help for seed:run
  -n, --name stringArray   name of the seed to run (can be used multiple times)
```

> Every seed now need to have `Name()` method which should return the name of the seed.

### **Testing**

Steps to test the changes made in this pull request, including any test cases that were added or modified.

- [x] Tested all new/updated features locally