### PR TITLE
Invoke required function reference

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -32,7 +32,7 @@ func WrapSubCommand(name string, cmd framework.Command, opt fx.Option) *cobra.Co
 
 			opts := fx.Options(
 				fx.WithLogger(logger.GetFxLogger),
-				fx.Invoke(cmd.Run()),
+				fx.Invoke(cmd.Run),
 			)
 			ctx := context.Background()
 			app := fx.New(opt, opts)


### PR DESCRIPTION
won't invoke nested module lifecycle onStart/onStop
👍🏿  Huge bug 
https://uber-go.github.io/fx/lifecycle.html#:~:text=run%20all%20functions%20passed%20to%20fx.Invoke%2C%20calling%20constructors%20and%20decorators%20as%20needed